### PR TITLE
ssh-host-keys should not be a static part of the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER b3vis
 #Install Borg & SSH
 RUN apk add openssh sshfs borgbackup supervisor --no-cache
 RUN adduser -D -u 1000 borg && \
-    ssh-keygen -A && \
     mkdir /backups && \
     chown borg.borg /backups && \
     sed -i \
@@ -11,6 +10,7 @@ RUN adduser -D -u 1000 borg && \
         -e 's/^PermitRootLogin without-password$/PermitRootLogin no/g' \
         /etc/ssh/sshd_config
 COPY supervisord.conf /etc/supervisord.conf
+COPY service.sh /usr/local/bin/service.sh
 RUN passwd -u borg
 EXPOSE 22
 CMD ["/usr/bin/supervisord"]

--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ docker create \
 ```
 
 ### Note
-After creating the container you will need to start the container add your own public keys
+After creating the container you will need to start the container add your own public keys.

--- a/service.sh
+++ b/service.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+ssh-keygen -A
+/usr/sbin/sshd -D

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
 
 [program:sshd]
-command=/usr/sbin/sshd -D
+command=/usr/local/bin/service.sh


### PR DESCRIPTION
Hi there,

I think it is not a good idea to create the SSH Host keys during the image creation process. It may be better to initially create them once the container is started. 

This change will make sure that they get created during startup if they don't exist.